### PR TITLE
Ecg split class definitions

### DIFF
--- a/rpg-npc-creator/rpg-npc-creator/Name.cs
+++ b/rpg-npc-creator/rpg-npc-creator/Name.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace rpg_npc_creator
+{
+    // Add a name to the NPCs
+    public class Name
+    {
+        string NpcName;
+
+        public void Set(string Name)
+        {
+            this.NpcName = Name;
+            Console.WriteLine("Name is now: " + Name);
+        }
+        public Name()
+        {
+            NpcName = "Nameless";
+            Console.WriteLine("New nameless NPC created");
+        }
+        public Name(string IncomingName)
+        {
+            NpcName = IncomingName;
+            Console.WriteLine("New NPC created with name: " + IncomingName);
+        }
+    }
+    // Create an interface to the Name
+    public interface IName
+    {
+        string NpcName { get; }
+    }
+}

--- a/rpg-npc-creator/rpg-npc-creator/Npc.cs
+++ b/rpg-npc-creator/rpg-npc-creator/Npc.cs
@@ -89,30 +89,4 @@ namespace rpg_npc_creator
     {
         int Value { get; }
     }
-    // Add a name to the NPCs
-    public class Name
-    {
-        string NpcName;
-
-        public void Set(string Name)
-        {
-            this.NpcName = Name;
-            Console.WriteLine("Name is now: " + Name);
-        }
-        public Name()
-        {
-            NpcName = "Nameless";
-            Console.WriteLine("New nameless NPC created");
-        }
-        public Name(string IncomingName)
-        {
-            NpcName = IncomingName;
-            Console.WriteLine("New NPC created with name: " + IncomingName);
-        }
-    }
-    // Create an interface to the Name
-    public interface IName
-    {
-        string NpcName { get; }
-    }
 }

--- a/rpg-npc-creator/rpg-npc-creator/Npc.cs
+++ b/rpg-npc-creator/rpg-npc-creator/Npc.cs
@@ -61,32 +61,4 @@ namespace rpg_npc_creator
         Stat Statistic { get; }
         Name NpcName { get; }
     }
-    // Add a stat to the NPC
-    public class Stat
-    {
-        int Value;
-
-        public void Set(int NewValue)
-        {
-            this.Value = NewValue;
-            Console.WriteLine("Stat Value is now: " + Value);
-        }
-
-        // Constructors
-        public Stat()
-        {
-            Value = 1;
-            Console.WriteLine("New Stat created with value: " + Value);
-        }
-        public Stat(int IncomingValue)
-        {
-            Value = IncomingValue;
-            Console.WriteLine("New Stat created with value: " + IncomingValue);
-        }
-    }
-    // Add an interface to a stat
-    public interface IStat
-    {
-        int Value { get; }
-    }
 }

--- a/rpg-npc-creator/rpg-npc-creator/Stat.cs
+++ b/rpg-npc-creator/rpg-npc-creator/Stat.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace rpg_npc_creator
+{
+    // Add a stat to the NPC
+    public class Stat
+    {
+        int Value;
+
+        public void Set(int NewValue)
+        {
+            this.Value = NewValue;
+            Console.WriteLine("Stat Value is now: " + Value);
+        }
+
+        // Constructors
+        public Stat()
+        {
+            Value = 1;
+            Console.WriteLine("New Stat created with value: " + Value);
+        }
+        public Stat(int IncomingValue)
+        {
+            Value = IncomingValue;
+            Console.WriteLine("New Stat created with value: " + IncomingValue);
+        }
+    }
+    // Add an interface to a stat
+    public interface IStat
+    {
+        int Value { get; }
+    }
+}

--- a/rpg-npc-creator/rpg-npc-creator/rpg-npc-creator.csproj
+++ b/rpg-npc-creator/rpg-npc-creator/rpg-npc-creator.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Logger.cs" />
+    <Compile Include="Name.cs" />
     <Compile Include="Npc.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/rpg-npc-creator/rpg-npc-creator/rpg-npc-creator.csproj
+++ b/rpg-npc-creator/rpg-npc-creator/rpg-npc-creator.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Npc.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Stat.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
Pull out the class definitions of Stat and Name into their own class files.
While NPC still depends on them, they are going to be confusing the longer they sit in the same location as the NPC file by sheer volume of code, especially once the Stat code gets more dynamic. 
